### PR TITLE
Fixes for proxying to a REST API

### DIFF
--- a/ProxyHandler.class.php
+++ b/ProxyHandler.class.php
@@ -145,6 +145,7 @@ class ProxyHandler
 
             switch($requestMethod) {
                 case 'POST':
+                case 'PATCH':
                     $data = '';
                     if (isset($options['data'])) {
                         $data = $options['data'];

--- a/ProxyHandler.class.php
+++ b/ProxyHandler.class.php
@@ -85,8 +85,9 @@ class ProxyHandler
         if (isset($options['baseUri'])) {
             $baseUri = $options['baseUri'];
         }
-        elseif (!empty($_SERVER['REDIRECT_URL'])) {
-            $baseUri = dirname($_SERVER['REDIRECT_URL']);
+        elseif (!empty($options['proxyUri'])) {
+            $baseUri = parse_url($options['proxyUri'], PHP_URL_PATH);
+            $baseUri = dirname($baseUri);
         }
 
         $requestUri = '';
@@ -296,7 +297,9 @@ class ProxyHandler
             $info = $this->getCurlInfo();
             if (isset($info['content_type'])) {
                 $this->_contentType = preg_replace('/;.*/', '', $info['content_type']);
-                if (in_array($this->_contentType, $this->_bufferedContentTypes)) {
+                if (is_array($this->_bufferedContentTypes)
+                    && in_array($this->_contentType, $this->_bufferedContentTypes)
+                ) {
                     $this->_buffered = true;
                 }
             }


### PR DESCRIPTION
- Adding PATCH support
- Fixing a couple of bugs
  - Base URI should be determined either from options, or the proxy URI,
    not from the requested URI. If from the requested, then it becomes
    impossible to proxy to a base path
    - eg: `http://example.com/api/x` proxying to
      `http://localhost:3000/api/x` instead goes to
      `http://localhost:3000/x`
  - Check that the list of buffered types is an array before attempting to
    use it. Throws PHP warnings otherwise.
    - It's passed in as an option, so in many cases it will be empty.