### PR TITLE
Fixed bufferedContentTypes default value

### DIFF
--- a/ProxyHandler.class.php
+++ b/ProxyHandler.class.php
@@ -33,7 +33,7 @@ class ProxyHandler
     /**
      * @type array
      */
-    private $_bufferedContentTypes = null;
+    private $_bufferedContentTypes = array();
     /**
      * @type string
      */


### PR DESCRIPTION
Without it you can get `Warning: in_array() expects parameter 2 to be array, null given in ProxyHandler.class.php on line 299`